### PR TITLE
Fix indicator separation calculation

### DIFF
--- a/render.c
+++ b/render.c
@@ -265,8 +265,8 @@ void render_frames(struct waylogout_surface *surface) {
 
 	int n_actions = wl_list_length(&state->actions);
 	int indicator_sep = (state->args.indicator_sep > 0)
-	  ? state->args.indicator_sep
-	  : (surface->width - n_actions * fr_common.indicator_diameter)
+	  ? (int) state->args.indicator_sep
+	  : (int) (surface->width * surface->scale - n_actions * fr_common.indicator_diameter)
 	    / (n_actions + 1)
 	;
 	if (indicator_sep < 0)

--- a/render.c
+++ b/render.c
@@ -272,8 +272,7 @@ void render_frames(struct waylogout_surface *surface) {
 	if (indicator_sep < 0)
 		indicator_sep = fr_common.arc_thickness;
 
-	// TODO should this be divided by surface->scale ?
-	fr_common.x_offset = fr_common.indicator_diameter + indicator_sep;
+	fr_common.x_offset = (fr_common.indicator_diameter + indicator_sep) / surface->scale;
 
 	fr_common.x_center = (state->args.override_indicator_x_position)
 			? state->args.indicator_x_position


### PR DESCRIPTION
Take the surface scale into account, and ensure signed numbers are used (otherwise the fallback can never be triggered).

Fixes #15.